### PR TITLE
bug/fix_date_output_issue

### DIFF
--- a/MyMediator.Tests.Unit/GlobalUsings.cs
+++ b/MyMediator.Tests.Unit/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  MyMediator.Tests.Unit
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
@@ -24,5 +22,3 @@ global using Microsoft.Extensions.DependencyInjection;
 global using NSubstitute;
 
 global using Xunit;
-
-#endregion

--- a/MyMediator/GlobalUsings.cs
+++ b/MyMediator/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  MyMediator
 // =======================================================
 
-#region
-
 global using System;
 global using System.Linq;
 global using System.Reflection;
@@ -16,5 +14,3 @@ global using System.Threading;
 global using System.Threading.Tasks;
 
 global using Microsoft.Extensions.DependencyInjection;
-
-#endregion

--- a/TailwindBlog.AppHost/GlobalUsings.cs
+++ b/TailwindBlog.AppHost/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  TailwindBlog.AppHost
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
@@ -19,5 +17,3 @@ global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
-
-#endregion

--- a/TailwindBlog.Architecture.Tests/GlobalUsings.cs
+++ b/TailwindBlog.Architecture.Tests/GlobalUsings.cs
@@ -4,8 +4,6 @@
 // Project Name:  TailwindBlog.Architecture.Tests
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections;
 global using System.Collections.Generic;
@@ -27,5 +25,3 @@ global using TailwindBlog.Persistence;
 global using TailwindBlog.Web;
 
 global using Xunit;
-
-#endregion

--- a/TailwindBlog.Domain/GlobalUsings.cs
+++ b/TailwindBlog.Domain/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  TailwindBlog.Domain
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.ComponentModel.DataAnnotations;
@@ -36,5 +34,3 @@ global using TailwindBlog.Domain.Interfaces;
 global using TailwindBlog.Domain.Validators;
 
 global using ValidationException = FluentValidation.ValidationException;
-
-#endregion

--- a/TailwindBlog.Persistence.MongoDb/GlobalUsings.cs
+++ b/TailwindBlog.Persistence.MongoDb/GlobalUsings.cs
@@ -4,8 +4,6 @@
 // Project Name:  TailwindBlog.Persistence.MongoDb
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
@@ -28,5 +26,3 @@ global using TailwindBlog.Domain.Helpers;
 global using TailwindBlog.Domain.Interfaces;
 global using TailwindBlog.Domain.Models;
 global using TailwindBlog.Persistence.Repositories;
-
-#endregion

--- a/TailwindBlog.ServiceDefaults/GlobalUsings.cs
+++ b/TailwindBlog.ServiceDefaults/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  TailwindBlog.ServiceDefaults
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Diagnostics;
@@ -28,5 +26,3 @@ global using Microsoft.Extensions.Logging;
 global using OpenTelemetry.Metrics;
 global using OpenTelemetry.Resources;
 global using OpenTelemetry.Trace;
-
-#endregion

--- a/TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.cs
+++ b/TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.cs
@@ -7,10 +7,6 @@
 // Project Name :  TailwindBlog.Web.Tests.Bunit
 // =======================================================
 
-#region
-
-#endregion
-
 namespace TailwindBlog.Web.Components.Layout;
 
 /// <summary>

--- a/TailwindBlog.Web.Tests.Bunit/GlobalUsings.cs
+++ b/TailwindBlog.Web.Tests.Bunit/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  TailwindBlog.Web.Tests.Bunit
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
@@ -44,5 +42,3 @@ global using TailwindBlog.Web.Components.Features.Articles.Models;
 global using TailwindBlog.Web.Services;
 
 global using Xunit;
-
-#endregion

--- a/TailwindBlog.Web/Components/App.razor
+++ b/TailwindBlog.Web/Components/App.razor
@@ -2,19 +2,20 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="/" />
-    <link rel="stylesheet" href="@Assets["css/app.css"]" />
-    <link rel="stylesheet" href="@Assets["TailwindBlog.Web.styles.css"]" />
-    <ImportMap />
-    <link rel="icon" type="image/png" href="favicon.png" />
-    <HeadOutlet />
+	<title>Tailwind Blog</title>
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+	<base href="/"/>
+	<link rel="stylesheet" href="@Assets["css/app.css"]"/>
+	<link rel="stylesheet" href="@Assets["TailwindBlog.Web.styles.css"]"/>
+	<ImportMap/>
+	<link rel="icon" type="image/png" href="favicon.png"/>
+	<HeadOutlet/>
 </head>
 
 <body>
-    <Routes />
-    <script src="_framework/blazor.web.js"></script>
+<Routes/>
+<script src="_framework/blazor.web.js"></script>
 </body>
 
 </html>

--- a/TailwindBlog.Web/Components/Pages/Error.razor
+++ b/TailwindBlog.Web/Components/Pages/Error.razor
@@ -8,31 +8,35 @@
 
 @if (ShowRequestId)
 {
-    <p>
-        <strong>Request ID:</strong> <code>@requestId</code>
-    </p>
+	<p>
+		<strong>Request ID:</strong> <code>@_requestId</code>
+	</p>
 }
 
 <h3>Development Mode</h3>
 <p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+	Swapping to <strong>Development</strong> environment will display more detailed information about the error that
+	occurred.
 </p>
 <p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
+	<strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+	It can result in displaying sensitive information from exceptions to end users.
+	For local debugging, enable the <strong>Development</strong> environment by setting the
+	<strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+	and restarting the app.
 </p>
 
 @code{
-    [CascadingParameter]
-    public HttpContext? HttpContext { get; set; }
 
-    private string? requestId;
-    private bool ShowRequestId => !string.IsNullOrEmpty(requestId);
+	[CascadingParameter] public HttpContext? HttpContext { get; set; }
 
-    protected override void OnInitialized()
-    {
-        requestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
-    }
+	private string? _requestId;
+
+	private bool ShowRequestId => !string.IsNullOrEmpty(_requestId);
+
+	protected override void OnInitialized()
+	{
+		_requestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+	}
+
 }

--- a/TailwindBlog.Web/Components/Shared/PostInfoComponent.razor
+++ b/TailwindBlog.Web/Components/Shared/PostInfoComponent.razor
@@ -1,12 +1,13 @@
+@using System.Globalization
 <div class="flex gap-4 border-t border-gray-200 pt-4">
 
 	<div>Author: @Article.Author.UserName</div>
 
-	<div>Created: @Article.CreatedOn.ToString("d")</div>
+	<div>Created: @Article.CreatedOn.ToString("M/d/yyyy", CultureInfo.InvariantCulture)</div>
 
 	@if(@Article.IsPublished)
 	{
-		<div>Published: @Article.PublishedOn?.ToString("d")</div>
+		<div>Published: @Article.PublishedOn?.ToString("M/d/yyyy", CultureInfo.InvariantCulture)</div>
 	}
 	else
 	{

--- a/TailwindBlog.Web/Components/_Imports.razor
+++ b/TailwindBlog.Web/Components/_Imports.razor
@@ -12,7 +12,6 @@
 @using TailwindBlog.Web
 @using TailwindBlog.Web.Components
 @using TailwindBlog.Web.Components.Features.Articles.Components
-@using TailwindBlog.Web.Components.Features.Articles.Components
 @using TailwindBlog.Web.Components.Features.Articles.Models
 @using TailwindBlog.Web.Components.Shared
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/TailwindBlog.Web/GlobalUsings.cs
+++ b/TailwindBlog.Web/GlobalUsings.cs
@@ -7,8 +7,6 @@
 // Project Name :  TailwindBlog.Web
 // =======================================================
 
-#region
-
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
@@ -23,5 +21,3 @@ global using TailwindBlog.Domain.Abstractions;
 global using TailwindBlog.Domain.Entities;
 global using TailwindBlog.Domain.Models;
 global using TailwindBlog.Web.Components;
-
-#endregion


### PR DESCRIPTION
This pull request removes unnecessary `#region` and `#endregion` directives across multiple `GlobalUsings.cs` files and makes minor adjustments to improve code readability and functionality in the `TailwindBlog.Web` project. The most important changes include the removal of redundant directives, updates to Razor components, and corrections to global imports.

### Cleanup of `GlobalUsings.cs` files:
* Removed `#region` and `#endregion` directives from `GlobalUsings.cs` files across multiple projects, including `MyMediator`, `TailwindBlog.AppHost`, `TailwindBlog.Domain`, `TailwindBlog.Persistence.MongoDb`, `TailwindBlog.ServiceDefaults`, and `TailwindBlog.Web`. This simplifies the structure and improves readability. [[1]](diffhunk://#diff-f394548d5c139823f1a4f5bd44cd299231fa9af43553c9cd0bbac99dc14600daL10-L11) [[2]](diffhunk://#diff-1ab4da9c6d17d2611955b495d080f32ea29cadfa7bcb7012c49a7b71477de054L10-L20) [[3]](diffhunk://#diff-7891799512680c713a6dfdd1aa117f6a30f03853e502123b6014c04d2a84e25fL10-L11) [[4]](diffhunk://#diff-02b7baad6bc1b273d74410ba3c7020fffa7cdf081ce5a05738497cad0f3de8ddL10-L11) [[5]](diffhunk://#diff-121150213c6784b43a10802bc4d0af2b4c1b328c94db1c68e6cd60847483f4d5L7-L8) [[6]](diffhunk://#diff-9f3d02bcece092caa7e2127b1f2b5d2861f44cb799ab53ce67e6fc284d013fe5L10-L11) [[7]](diffhunk://#diff-d554d3143bdc7ea78b8493946f84dd722903a30bb8bec4283db8e1762476f69eL10-L11)

### Updates to Razor components:
* Added a `<title>` tag to the `App.razor` component to set the page title to "Tailwind Blog".
* Refactored `Error.razor` to use `_requestId` instead of `requestId` for consistency and updated formatting for better readability.
* Updated `PostInfoComponent.razor` to ensure date formatting uses the invariant culture (`M/d/yyyy`), improving consistency across locales.

### Code corrections and enhancements:
* Removed duplicate import in `_Imports.razor` to clean up unnecessary redundancy.

These changes collectively enhance code maintainability, readability, and consistency across the project.