### PR TITLE
bug/fix_footercomponent

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -82,7 +82,7 @@ jobs:
         if: always()
         with:
           files: |
-            TestResults/**/*.xml
+            TestResults/**/*.trx
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.cs
+++ b/TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.cs
@@ -22,10 +22,12 @@ public class FooterComponentTest : BunitContext
 	{
 
 		// Arrange
-		const string expectedHtml =
-				"""
+		var currentYear = DateTime.Now.Year;
+
+		var expectedHtml =
+				$"""
 				<div class="text-center px-6 py-2 mx-auto xl:max-w-5xl border-t-blue-700">
-				  <a href="/">© 2023 MPaulosky Co. All rights reserved.</a>
+				  <a href="/">©{currentYear} MPaulosky Co. All rights reserved.</a>
 				</div>
 				""";
 

--- a/TailwindBlog.Web/Components/Layout/FooterComponent.razor
+++ b/TailwindBlog.Web/Components/Layout/FooterComponent.razor
@@ -1,12 +1,14 @@
 
 <div class="text-center px-6 py-2 mx-auto xl:max-w-5xl border-t-blue-700">
 
-	<a href="/">© @CurrentYear @_companyName All rights reserved.</a>
+	<a href="/">©@_currentYear @_companyName All rights reserved.</a>
 
 </div>
 
 @code {
 
 	private const string _companyName = "MPaulosky Co.";
+
+	private static readonly string _currentYear = DateTime.Now.Year.ToString();
 
 }


### PR DESCRIPTION
This pull request introduces updates to the footer component to dynamically display the current year and modifies the test workflow to use `.trx` files for test results. The most important changes are grouped below:

### Footer Component Updates:
* Updated `FooterComponent.razor` to dynamically calculate the current year using a new static readonly field `_currentYear`. This replaces the hardcoded year in the footer text. (`TailwindBlog.Web/Components/Layout/FooterComponent.razor`, [TailwindBlog.Web/Components/Layout/FooterComponent.razorL4-R13](diffhunk://#diff-ef23f9fa203131ced16466d025fe0a2857a33d755eded3d8d35b8c292ef17b7fL4-R13))
* Adjusted the `Should_Render_Footer_Text` test in `FooterComponentTest.cs` to use the current year dynamically in the expected HTML, ensuring the test accommodates the updated footer logic. (`TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.cs`, [TailwindBlog.Web.Tests.Bunit/Components/Layout/FooterComponentTest.csL25-R30](diffhunk://#diff-83c8faaf1687006a5584fd3cc05181d355006dc66a0ba1055d4f14a0be73ea4dL25-R30))

### Test Workflow Update:
* Updated the `.github/workflows/dotnet.yml` file to collect test results using `.trx` files instead of `.xml` files, aligning with the output format of the test framework. (`.github/workflows/dotnet.yml`, [.github/workflows/dotnet.ymlL85-R85](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L85-R85))