### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,14 +54,15 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore
-
+        
       - name: Create Test Results Directory
         run: mkdir -p TestResults
-
+      
       - name: Run all tests in all test projects
         run: |
           for proj in $(find . -name "*.csproj" -path "*/Tests/*"); do
-            dotnet test "$proj" --logger "trx;LogFileName=../../TestResults/$(basename $proj .csproj).trx"
+            name=$(basename "$proj" .csproj)
+            dotnet test "$proj" --logger "trx;LogFileName=TestResults/${name}.trx"
           done
 
       - name: Upload Test Results

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run all tests in all test projects
         run: |
           for proj in $(find . -name "*.csproj" -path "*/Tests/*"); do
-            dotnet test "$proj" --logger "trx;LogFileName=TestResults/$(basename $proj .csproj).trx"
+            dotnet test "$proj" --logger "trx;LogFileName=../../TestResults/$(basename $proj .csproj).trx"
           done
 
       - name: Upload Test Results


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/dotnet.yml` file. The change updates the path for test result log files to ensure they are saved in the correct directory during the workflow execution.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L64-R64): Updated the `dotnet test` command to save test result log files in the `../../TestResults/` directory instead of the previous relative path.